### PR TITLE
Rename name to _name

### DIFF
--- a/lib/rom_factory/builder.rb
+++ b/lib/rom_factory/builder.rb
@@ -8,8 +8,8 @@ module RomFactory
 
     def self.define(&block)
       factory = new(&block)
-      raise ArgumentError, "Factory with key #{factory.name} already present" if container.key?(factory.name)
-      container.register(factory.name, factory)
+      raise ArgumentError, "Factory with key #{factory._name} already present" if container.key?(factory._name)
+      container.register(factory._name, factory)
     end
 
     def self.create(name, attrs = {})
@@ -24,7 +24,7 @@ module RomFactory
 
     def factory(name:, relation:, &block)
       @_relation = RomFactory::Config.config.container.relations.fetch(relation)
-      @name = name
+      @_name = name
       @_schema = {}
       define_methods_from_relation
       yield(self)
@@ -42,7 +42,7 @@ module RomFactory
       OpenStruct.new(_relation.where(id: record_id).one)
     end
 
-    attr_reader :name
+    attr_reader :_name
 
     private
 


### PR DESCRIPTION
I'm in the proccess of replacing ActiveRecord with ROM in my [grape-embryo](https://github.com/wilsonsilva/grape-embryo) repo. That project has table named `people`, with a column called `name`.

Setting up a factory using RomFactory fails in this scenario because `RomFactory::Builder` has its own `name` attribute. That `name` is replaced when `define_methods_from_relation` is executed.

```
  1) Embryo::Operations::People::DeletePerson#call when the person exists deletes a person
     Failure/Error: let!(:person) { RomFactory::Builder.create(:person) }

     ArgumentError:
       Factory person does not exist
     # ./spec/embryo/operations/people/delete_person_spec.rb:10:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:39:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:38:in `block (2 levels) in <top (required)>'
```

I renamed `name` to `_name` to avoid these collisions.
