### PR TITLE
Update to work with rom 3

### DIFF
--- a/lib/rom_factory/factory.rb
+++ b/lib/rom_factory/factory.rb
@@ -18,7 +18,7 @@ module RomFactory
     end
 
     def sequence(method_id, &block)
-      if _relation.attributes.include?(method_id)
+      if _relation.schema.attributes.map(&:name).include?(method_id)
         define_sequence_method(method_id, block)
       end
       self.send(method_id)
@@ -35,7 +35,7 @@ module RomFactory
     end
 
     def method_missing(method_id, *arguments, &block)
-      if _relation.attributes.include?(method_id)
+      if _relation.schema.attributes.map(&:name).include?(method_id)
         define_regular_method(method_id)
         self.send(method_id, *arguments, &block)
       else

--- a/rom_factory.gemspec
+++ b/rom_factory.gemspec
@@ -33,9 +33,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.13'
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "rom", "~> 2.0"
-  spec.add_development_dependency "rom-repository", "~> 0.3"
-  spec.add_development_dependency "rom-sql", "~> 0.8"
+  spec.add_development_dependency "rom", "~> 3.0"
+  spec.add_development_dependency "rom-repository", "~> 1.0"
+  spec.add_development_dependency "rom-sql", "~> 1.0"
   spec.add_development_dependency "sqlite3", "~> 1.3"
   spec.add_development_dependency "pry", "~> 0.10"
 end


### PR DESCRIPTION
There was a slight change to the relation API in rom 3 that broke rom_factory. This change makes it work again with rom 3.

I figured that backwards compatibility wasn't too much of a concern for rom_factory at this point, and we really want to be encouraging people to get onto the new stuff anyway :)